### PR TITLE
Fix Codex remote marketplace installation

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,14 +1,15 @@
 {
-  "name": "superra-local",
+  "name": "superra",
   "interface": {
-    "displayName": "Local superRA Plugins"
+    "displayName": "superRA"
   },
   "plugins": [
     {
       "name": "superra",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "url",
+        "url": "https://github.com/FuZhiyu/superRA.git",
+        "ref": "main"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FuZhiyu/superRA.git",
-        "ref": "fix/codex-marketplace-install"
+        "ref": "main"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FuZhiyu/superRA.git",
-        "ref": "main"
+        "ref": "fix/codex-marketplace-install"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "superRA skills for disciplined research-assistant workflows in Codex.",
   "author": "Zhiyu Fu",
   "homepage": "https://github.com/FuZhiyu/superRA",
@@ -17,7 +17,7 @@
   "interface": {
     "displayName": "superRA",
     "shortDescription": "Disciplined research-assistant workflows for Codex.",
-    "longDescription": "superRA adds plan, execution, review, integration, and merge discipline for research-oriented coding workflows. Install the plugin for shared skills, then run codex-superra-setup to install the named Codex agents.",
+    "longDescription": "superRA adds plan, execution, review, integration, and merge discipline for research-oriented coding workflows. Install the shared skills from the superRA marketplace entry, then run codex-superra-setup to install the named Codex agents.",
     "developerName": "Zhiyu Fu",
     "category": "Productivity",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -128,11 +128,9 @@ If you want to modify superRA itself — edit skills, add a domain vertical, tun
 
 ```bash
 git clone https://github.com/FuZhiyu/superRA.git
-claude plugin marketplace add ./superRA
-claude plugin install superRA@superRA
 ```
 
-Edits to your clone are picked up on the next session start.
+The committed repo marketplace now targets the published GitHub source so remote installs work cleanly in Codex. For a live local-development install, create your own personal marketplace entry that points directly at your clone instead of relying on the repo's committed marketplace file.
 
 ### Codex
 
@@ -143,7 +141,22 @@ Codex installation has two pieces:
 
 This split is Codex-specific and deliberate. In Codex, plugins are the installable distribution unit for shared skills, while custom agents are discovered separately from `~/.codex/agents/`.
 
-#### Global install (recommended for normal cross-repo use)
+#### Remote marketplace install (recommended)
+
+1. Add the repo as a marketplace:
+
+   ```bash
+   codex plugin marketplace add FuZhiyu/superRA
+   ```
+
+2. Restart Codex, open the Plugins UI (or run `/plugins` in the CLI), and install `superra`.
+3. Run `codex-superra-setup`.
+4. Choose **global** scope so `superra_implementer` and `superra_reviewer` install into `~/.codex/agents/`.
+5. Restart Codex or start a fresh session if agent discovery has not refreshed yet.
+
+Codex should cache the plugin after install under `~/.codex/plugins/cache/...`.
+
+#### Manual local-clone install (for development or explicit local control)
 
 1. Clone this repo somewhere durable:
 
@@ -183,7 +196,8 @@ This split is Codex-specific and deliberate. In Codex, plugins are the installab
 
 #### Updating a Codex install
 
-- **Plugin updates:** Codex's local plugin install tracks the directory named in the marketplace entry. Update that directory, then restart Codex so it reloads the plugin files. For the recommended install, that usually means `git -C ~/.codex/plugins/superra pull`.
+- **Remote marketplace install:** update the marketplace and plugin from Codex, then restart if the UI has not refreshed yet.
+- **Manual local-clone install:** Codex tracks the directory named in your personal marketplace entry. Update that clone, then restart Codex so it reloads the plugin files. For the example above, that usually means `git -C ~/.codex/plugins/superra pull`.
 - **Agent updates:** rerun `codex-superra-setup` after updating if you want to refresh the generated custom agents. This is required whenever [`agents/implementer.md`](./agents/implementer.md) or [`agents/reviewer.md`](./agents/reviewer.md) changes.
 - **Verification:** the global install should create `~/.codex/agents/superra_implementer.toml` and `~/.codex/agents/superra_reviewer.toml`.
 

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -11,6 +11,20 @@ Use **global agent install** for normal work across other repos.
 
 ## Recommended Setup
 
+### Remote marketplace install
+
+1. Add the repo as a marketplace:
+   ```bash
+   codex plugin marketplace add FuZhiyu/superRA
+   ```
+2. Restart Codex and install the `superra` plugin.
+3. Run `codex-superra-setup`.
+4. Choose **global** scope so `superra_implementer` and `superra_reviewer` install into `~/.codex/agents/`.
+
+Codex should cache the installed plugin under `~/.codex/plugins/cache/...`.
+
+### Manual local-clone install
+
 1. Clone this repo to a durable location, for example:
    ```bash
    git clone https://github.com/FuZhiyu/superRA.git ~/.codex/plugins/superra
@@ -19,6 +33,8 @@ Use **global agent install** for normal work across other repos.
 3. Restart Codex and install the `superra` plugin.
 4. Run `codex-superra-setup`.
 5. Choose **global** scope so `superra_implementer` and `superra_reviewer` install into `~/.codex/agents/`.
+
+Use this path when you want the plugin to track a local clone directly.
 
 ## Why This Split Exists
 

--- a/tests/check-harness-compatibility.sh
+++ b/tests/check-harness-compatibility.sh
@@ -42,8 +42,9 @@ assert plugin["name"] == "superra", plugin["name"]
 assert plugin["skills"] == "./skills/", plugin["skills"]
 assert "skills" in plugin["interface"]["capabilities"], plugin["interface"]["capabilities"]
 assert entry["name"] == plugin["name"], (entry["name"], plugin["name"])
-assert entry["source"]["source"] == "local", entry["source"]
-assert entry["source"]["path"] == "./", entry["source"]["path"]
+assert entry["source"]["source"] == "url", entry["source"]
+assert entry["source"]["url"] == "https://github.com/FuZhiyu/superRA.git", entry["source"]["url"]
+assert entry["source"]["ref"] == "main", entry["source"]["ref"]
 PY
 
 section "Shared harness adapters"


### PR DESCRIPTION
## Summary
- switch the committed Codex marketplace entry from an invalid local root path to a Git-backed repo-root plugin source
- bump the plugin metadata version and clarify the Codex install surface copy
- document the supported Codex install paths: remote marketplace install and manual local-clone install

## Validation
- python3 -m json.tool .agents/plugins/marketplace.json
- python3 -m json.tool .codex-plugin/plugin.json
- git diff --check