### PR TITLE
Fix parallel worktree branch namespace

### DIFF
--- a/.codex/agents/superra_implementer.toml
+++ b/.codex/agents/superra_implementer.toml
@@ -138,7 +138,7 @@ git add [code files] PLAN.md RESULTS.md results_attachments/
 git commit -m "task N: [brief description]"
 ```
 
-**Parallel worktree dispatch (`Worktree:` field set).** Return the `<branch>/parallel/<slug>` branch name and HEAD SHA in your status report. Do not merge, rebase, push, or touch worktree lifecycle — the orchestrator owns harvest-out.
+**Parallel worktree dispatch (`Worktree:` field set).** Return the `<current-branch>-agent/parallel/<slug>` branch name and HEAD SHA in your status report. Do not merge, rebase, push, or touch worktree lifecycle — the orchestrator owns harvest-out.
 
 ## Pre-Commit Self-Check
 
@@ -161,7 +161,7 @@ Report:
 - **Key findings:** Headline numbers or surprises only. Point at RESULTS.md Task N section for tables, figures, and full context.
 - **Concerns (if any):** Data quality issues, methodology questions, unexpected results. Bullet points.
 - **Doc edits (what changed since the previous dispatch):** List each file and the specific sections/fields you modified, describing the change. Example: `PLAN.md — Task 3: rewrote Step 2 (merge approach changed after data inspection), marked Steps 1-3 [x], set Review status: IMPLEMENTED, annotated review items 1 and 2 with → implemented markers. RESULTS.md — Task 3 section replaced with new findings and 2 figures.` Say "none" if you touched neither file.
-- **Worktree return (path B only):** branch name (`<branch>/parallel/<slug>`) and HEAD SHA. Omit this field entirely on path A.
+- **Worktree return (path B only):** branch name (`<current-branch>-agent/parallel/<slug>`) and HEAD SHA. Omit this field entirely on path A.
 
 If the orchestrator needs more than this, they will read the docs directly.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+# Worktree Branch Naming Fix Plan
+
+> **For agentic workers:** Use `superRA:handoff-doc` for PLAN.md / RESULTS.md edits. This repo-internal fix follows direct mode: the main agent plays implementer and reviewer in-session.
+
+**Objective:** Replace the parallel-worktree branch naming protocol that creates nested refs under the current branch with a non-conflicting namespace that still contains `/parallel/`.
+
+**Methodology:** Update the owning orchestration instructions and active assertion surfaces only; preserve historical plan/result records as history unless they are active tests or current docs.
+
+**Output:** Updated skill/agent/hook guidance plus regenerated direct-mode artifacts if their source changes.
+
+---
+
+## Workflow Status
+
+- [x] **Plan approved** - researcher requested this direct-mode repo-internal fix.
+- [x] **Execution complete** - task implementation approved and targeted verification passed.
+- [ ] **Merged** - branch pushed and PR opened.
+
+---
+
+## Project Conventions
+
+Walked at planning time (2026-04-24). Re-walk on-demand only.
+
+### Repo root
+- `AGENTS.md`: contributor discipline for superRA internals; skill edits are skill creation, owning files must be read before editing, generated artifacts stay generated, and the DRY/Necessity tests are blocking gates for `skills/*` and `agents/*` instruction edits.
+- `README.md`: user-facing product overview and installation docs; keep contributor/internal protocol details in skill and contributor files rather than duplicating them here.
+
+### Module-level docs walked
+- `skills/using-superRA/SKILL.md` and `skills/using-superRA/references/main-agent.md`: direct mode requires role references, self-review, and reviewer discipline.
+- `skills/agent-orchestration/SKILL.md`: owns cross-stage dispatch patterns and worktree branch lifecycle protocol.
+- `skills/handoff-doc/SKILL.md`: `PLAN.md` / `RESULTS.md` are live committed handoff docs with inline-edit discipline.
+
+### Not walked
+- Historical `docs/plans/` records except targeted grep hits; they are not active instruction sources for this fix.
+
+---
+
+### Task 1: Fix parallel worktree branch namespace
+**Depends on:** *(none)*
+**Review status:** APPROVED
+
+**Input:** Active instruction surfaces matching the old `<branch>/parallel/<slug>` or equivalent pattern.
+**Output:** New namespace guidance using `<current-branch>-agent/parallel/<slug>` or an equivalent non-conflicting pattern, with `/parallel/` preserved for `merge-guard`.
+
+- [x] **Step 1: Locate active assertion surfaces.** Searched active skill, agent, hook, test, generated, and top-level doc surfaces. Historical `docs/plans/` records were left untouched.
+- [x] **Step 2: Update the owning protocol.** Changed `skills/agent-orchestration/SKILL.md` to create and merge `${current_branch}-agent/parallel/<slug>` branches rather than `${current_branch}/parallel/<slug>`.
+- [x] **Step 3: Update active references and source text.** Updated current references, merge-guard comments, implementer source text, generator source string, and regenerated the project-scope Codex implementer artifact.
+- [x] **Step 4: Verify behavior.** Ran targeted grep checks, merge-guard regression inputs, generator drift check, and a throwaway Git-ref creation check showing the old pattern fails under an existing leaf ref while the new pattern succeeds.

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,7 +14,7 @@
 
 - [x] **Plan approved** - researcher requested this direct-mode repo-internal fix.
 - [x] **Execution complete** - task implementation approved and targeted verification passed.
-- [ ] **Merged** - branch pushed and PR opened.
+- [x] **Merged** - branch pushed and PR opened: https://github.com/FuZhiyu/superRA/pull/23.
 
 ---
 

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -5,6 +5,8 @@
 **Last updated:** 2026-04-24 (Task 1 approved)
 **Status:** Completed
 
+**PR:** https://github.com/FuZhiyu/superRA/pull/23
+
 ---
 
 ## Task 1: Fix parallel worktree branch namespace

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,23 @@
+# Worktree Branch Naming Fix - Results
+
+> Mirrors PLAN.md structure. Updated after each step with key findings.
+
+**Last updated:** 2026-04-24 (Task 1 approved)
+**Status:** Completed
+
+---
+
+## Task 1: Fix parallel worktree branch namespace
+
+**Status:** Completed (Task 1 approved 2026-04-24)
+
+### Key Findings
+- The old `${current_branch}/parallel/<slug>` protocol fails when `${current_branch}` already exists as a branch ref because Git cannot create `refs/heads/<branch>/...` under an existing `refs/heads/<branch>` leaf.
+- The new `${current_branch}-agent/parallel/<slug>` protocol preserves the `/parallel/` infix used by `merge-guard` while avoiding that ref namespace collision.
+- Active runtime surfaces now point to `<current-branch>-agent/parallel/<slug>`; historical `docs/plans/` records were left unchanged as historical records.
+
+### Verification
+- `python3 scripts/sync_codex_agents.py --scope project --check`
+- `bash hooks/merge-guard` regression inputs for `foo-agent/parallel/a`, `feat-agent/parallel/b`, `main`, and `--abort`
+- Active-surface grep for old branch-name patterns under `skills`, `agents`, `hooks`, `tests`, `.codex`, `README.md`, and `AGENTS.md`
+- Throwaway Git repo ref test: `feature/parallel/a` failed under existing `feature`; `feature-agent/parallel/a` succeeded

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -134,7 +134,7 @@ git add [code files] PLAN.md RESULTS.md results_attachments/
 git commit -m "task N: [brief description]"
 ```
 
-**Parallel worktree dispatch (`Worktree:` field set).** Return the `<branch>/parallel/<slug>` branch name and HEAD SHA in your status report. Do not merge, rebase, push, or touch worktree lifecycle — the orchestrator owns harvest-out.
+**Parallel worktree dispatch (`Worktree:` field set).** Return the `<current-branch>-agent/parallel/<slug>` branch name and HEAD SHA in your status report. Do not merge, rebase, push, or touch worktree lifecycle — the orchestrator owns harvest-out.
 
 ## Pre-Commit Self-Check
 
@@ -157,7 +157,7 @@ Report:
 - **Key findings:** Headline numbers or surprises only. Point at RESULTS.md Task N section for tables, figures, and full context.
 - **Concerns (if any):** Data quality issues, methodology questions, unexpected results. Bullet points.
 - **Doc edits (what changed since the previous dispatch):** List each file and the specific sections/fields you modified, describing the change. Example: `PLAN.md — Task 3: rewrote Step 2 (merge approach changed after data inspection), marked Steps 1-3 [x], set Review status: IMPLEMENTED, annotated review items 1 and 2 with → implemented markers. RESULTS.md — Task 3 section replaced with new findings and 2 figures.` Say "none" if you touched neither file.
-- **Worktree return (path B only):** branch name (`<branch>/parallel/<slug>`) and HEAD SHA. Omit this field entirely on path A.
+- **Worktree return (path B only):** branch name (`<current-branch>-agent/parallel/<slug>`) and HEAD SHA. Omit this field entirely on path A.
 
 If the orchestrator needs more than this, they will read the docs directly.
 

--- a/hooks/merge-guard
+++ b/hooks/merge-guard
@@ -4,8 +4,8 @@
 # Does NOT block — the discipline system handles enforcement.
 
 # Test vectors for regression (from RESULTS.md Task 4)
-# - `git merge foo/parallel/a` → emit `{}` (exempt: parallel branch)
-# - `git merge --no-ff feat/parallel/b` → emit `{}` (exempt: parallel branch with flag)
+# - `git merge foo-agent/parallel/a` → emit `{}` (exempt: parallel branch)
+# - `git merge --no-ff feat-agent/parallel/b` → emit `{}` (exempt: parallel branch with flag)
 # - `git merge main` → emit STOP reminder (require semantic-merge)
 # - `git merge --abort` → emit `{}` (skip: abort is not a new merge)
 
@@ -36,7 +36,7 @@ fi
 
 # Exempt orchestrator-managed parallel-task merges.
 # Branch-name convention from superRA:agent-orchestration §Parallelization
-# and Worktree Isolation — <branch>/parallel/<slug> branches are disjoint
+# and Worktree Isolation — <current-branch>-agent/parallel/<slug> branches are disjoint
 # by construction and merge with plain git merge.
 if echo "$command" | grep -qE 'git (merge|rebase|cherry-pick)(\s+--?\S+)*\s+\S+/parallel/'; then
   printf '{}\n'

--- a/skills/agent-orchestration/SKILL.md
+++ b/skills/agent-orchestration/SKILL.md
@@ -85,7 +85,8 @@ Parallel agents **must** run in separate worktrees. Create each with raw git bef
 CLaude Code Agents: branching off the current branch, **not** via the `Agent` tool's `isolation: "worktree"` parameter — that branches off main's HEAD and the subagent cannot see in-flight state:
 
 ```bash
-git worktree add -b "$(git branch --show-current)/parallel/<slug>" <worktree-path> HEAD
+current_branch="$(git branch --show-current)"
+git worktree add -b "${current_branch}-agent/parallel/<slug>" <worktree-path> HEAD
 ```
 
 The `/parallel/` infix matters: the `merge-guard` hook exempts `*/parallel/*` source refs on merge-back. Pass the absolute `<worktree-path>` via the dispatch `Worktree:` field. The subagent enters via `EnterWorktree(path=...)` (or `cd` as fallback), works on whatever branch the worktree is on, and **never creates its own worktree or touches the branch name**. The `Worktree:` field in the dispatch **requires** this steering in `Additionally:`:
@@ -94,7 +95,7 @@ The `/parallel/` infix matters: the `merge-guard` hook exempts `*/parallel/*` so
 
 **Seeding data in.** Use `worktree-data-sync` in `--mode seed`. **Always pass `--from "$(pwd)"` (or an explicit path)** — never rely on `sync_worktree_data.py`'s `--from` default, which points at the main worktree, not the orchestrator's analysis worktree.
 
-**Harvest-out and conflicts.** `git merge --no-ff <branch>/parallel/<slug>`. Task boundaries are set ex-ante in `PLAN.md`, so parallel branches are mechanically disjoint and typically merge cleanly. If a conflict surfaces, resolve trivial adjacent edits inline; escalate material ones to the researcher. Cleanup: `git worktree remove` + `git branch -D`.
+**Harvest-out and conflicts.** `git merge --no-ff <current-branch>-agent/parallel/<slug>`. Task boundaries are set ex-ante in `PLAN.md`, so parallel branches are mechanically disjoint and typically merge cleanly. If a conflict surfaces, resolve trivial adjacent edits inline; escalate material ones to the researcher. Cleanup: `git worktree remove` + `git branch -D`.
 
 Transient state (branch names, HEAD SHAs, worktree paths) is not persisted in `PLAN.md` — git (`git worktree list`, `git branch`) is the source of truth.
 

--- a/skills/agent-orchestration/references/agent-teams.md
+++ b/skills/agent-orchestration/references/agent-teams.md
@@ -100,7 +100,7 @@ When dispatching parallel agents that need isolated workspaces, follow `SKILL.md
 
 - Provision one worktree per agent per `references/worktree-harness-fallback.md` (harness tools preferred; raw `git worktree` otherwise).
 - Seed non-git data via `superRA:worktree-data-sync` §`--mode seed` with `--seed-sync-mode force-symlink`.
-- Merge back with plain `git merge` on the `<branch>/parallel/<slug>` branches.
+- Merge back with plain `git merge` on the `<current-branch>-agent/parallel/<slug>` branches.
 
 Do not hand-roll worktree setup or data-copy scripts.
 

--- a/skills/agent-orchestration/references/worktree-harness-fallback.md
+++ b/skills/agent-orchestration/references/worktree-harness-fallback.md
@@ -15,7 +15,7 @@ git worktree add <path> -b <branch-name> <base-ref>
 ```
 
 - `<path>` — absolute or repo-relative. Placement convention below.
-- `<branch-name>` — new branch to create at `<base-ref>`. For orchestrator-managed parallel slots, use `<analysis-branch>/parallel/<slug>`.
+- `<branch-name>` — new branch to create at `<base-ref>`. For orchestrator-managed parallel slots, use `<current-branch>-agent/parallel/<slug>`.
 - `<base-ref>` — typically the current analysis branch (`HEAD` is fine when already on it).
 
 After creation, the orchestrator seeds non-git data via `skills/worktree-data-sync` §`--mode seed` if the task needs data access.
@@ -68,12 +68,11 @@ Global-location worktrees (e.g., `~/.config/superpowers/worktrees/<project>/`) n
 One parallel slot's full lifecycle (create → seed → dispatch → merge → cleanup):
 
 ```bash
-WT=".worktrees/$BR/parallel/$SLUG"
-git worktree add "$WT" -b "$BR/parallel/$SLUG" "$BR"
+WT=".worktrees/${BR}-agent/parallel/$SLUG"
+git worktree add "$WT" -b "${BR}-agent/parallel/$SLUG" "$BR"
 python3 skills/worktree-data-sync/scripts/sync_worktree_data.py \
   --from "$(pwd)" --to "$WT" --mode seed --seed-sync-mode force-symlink
 # dispatch implementer with Worktree: <absolute path to $WT>
-git merge --no-ff "$BR/parallel/$SLUG"
-git worktree remove "$WT" && git branch -D "$BR/parallel/$SLUG"
+git merge --no-ff "${BR}-agent/parallel/$SLUG"
+git worktree remove "$WT" && git branch -D "${BR}-agent/parallel/$SLUG"
 ```
-

--- a/skills/codex-superra-setup/scripts/sync_codex_agents.py
+++ b/skills/codex-superra-setup/scripts/sync_codex_agents.py
@@ -357,7 +357,7 @@ def cleanup_implementer_handoff(section: str) -> str:
     # a subagent dispatch field.
     worktree_block = (
         "\n\n**Parallel worktree dispatch (`Worktree:` field set).** Return the "
-        "`<branch>/parallel/<slug>` branch name and HEAD SHA in your status "
+        "`<current-branch>-agent/parallel/<slug>` branch name and HEAD SHA in your status "
         "report. Do not merge, rebase, push, or touch worktree lifecycle — the "
         "orchestrator owns harvest-out."
     )

--- a/skills/semantic-merge/SKILL.md
+++ b/skills/semantic-merge/SKILL.md
@@ -11,7 +11,7 @@ Integrate branches by intent, not by lines. Understand what each side was trying
 
 **Upstream-intent rule:** Identify the governing upstream intent before changing files. In Phase B, use the active `## Upstream Intent` section in `PLAN.md` when the reviewer recorded one for the current round, plus any relevant task-local review notes. Otherwise use the caller-supplied upstream-intent context for the incoming objective and allowed deltas. Preserve base intent by default: the merged tree should match the base branch unless approved task objectives or the recorded contract explicitly authorize a surviving branch-side delta. Upstream deletions and relocations stay deleted or relocated unless the recorded contract says otherwise.
 
-**Exception — orchestrator-managed parallel worktrees bypass this skill.** Branches matching `<branch>/parallel/<slug>` merge with plain `git merge --no-ff` (the `merge-guard` hook exempts `*/parallel/*` source refs).
+**Exception — orchestrator-managed parallel worktrees bypass this skill.** Branches matching `<current-branch>-agent/parallel/<slug>` merge with plain `git merge --no-ff` (the `merge-guard` hook exempts `*/parallel/*` source refs).
 
 ## The Process
 


### PR DESCRIPTION
## Summary
- change orchestrator-managed parallel worktree branches to `<current-branch>-agent/parallel/<slug>` so Git does not create nested refs under an existing branch leaf
- keep the `/parallel/` infix used by merge-guard and update active skill, reference, hook, agent, and generated Codex implementer surfaces
- add side-job PLAN.md / RESULTS.md documenting direct-mode implementation and review

## Verification
- `python3 scripts/sync_codex_agents.py --scope project --check`
- `bash hooks/merge-guard` regression inputs for `foo-agent/parallel/a`, `feat-agent/parallel/b`, `main`, and `--abort`
- active-surface grep for old branch-name patterns under `skills`, `agents`, `hooks`, `tests`, `.codex`, `README.md`, and `AGENTS.md`
- throwaway Git repo ref test: `feature/parallel/a` fails under existing `feature`; `feature-agent/parallel/a` succeeds