### PR TITLE
[codex] Restrict Claude Fable dispatches

### DIFF
--- a/skills/agent-orchestration/SKILL.md
+++ b/skills/agent-orchestration/SKILL.md
@@ -63,6 +63,8 @@ Harnesses expose multiple tiers of model capacity (Sonnet vs. Opus in Claude Cod
 - **Adversarial first-pass review.** The failure mode is *not noticing* — capacity buys thoroughness, and lower-tier agents tend to over-comply, which breaks adversarial review. Narrow re-review of a cited fix stays on Sonnet.
 - **Heavy context synthesis.** Many files/skills must be reconciled in one head; Sonnet degrades faster under context pressure.
 
+For Claude agents, Fable is reserved for the most challenging, expensive tasks; use it only when the task has substantial unknowns or very high complexity.
+
 These are defaults, not rules. Use your discretion and honor any explicit user preference.
 
 ### Rules of thumb


### PR DESCRIPTION
## Summary

- Adds Claude-specific guidance in `agent-orchestration` model-tier selection that Fable is reserved for the most challenging tasks.
- Limits Fable use to tasks with substantial unknowns or very high complexity.

## Rationale

Fable is really expensive, so orchestration should not dispatch it lightly. The guidance lives where the orchestrator already decides workload and model tier, rather than in role specs or dispatch templates.

## Validation

- `bash tests/hooks/test-ensure-agent-orchestration.sh`
- `bash tests/test-sync-integration-contract.sh`
- `git diff --check`
- `rg -n "Fable|fable" skills agents README.md AGENTS.md`

`bash tests/check-harness-compatibility.sh` also passed its contract and generator sections, but exited nonzero because the fresh worktree is missing pre-existing `.agents/skills` symlinks for `mistral-pdf-to-markdown` and `zotero-paper-reader`; this PR does not touch packaging symlinks.