### PR TITLE
Plan explicit model selection for generic agent dispatches

### DIFF
--- a/superRA/agent-model-selection/01-dispatch-contract/task.md
+++ b/superRA/agent-model-selection/01-dispatch-contract/task.md
@@ -6,17 +6,17 @@ depends_on: []
 
 ## Objective
 
-Make explicit generic-agent model selection a single, actionable orchestration contract that both harness adapters and every generic dispatch call site implement without duplicating the tier rubric.
+Make explicit generic-agent model selection a single, actionable orchestration contract that both harnesses and every generic dispatch call site implement without duplicating the tier rubric.
 
 - Update `agent-orchestration` so every generic dispatch explicitly chooses its model configuration at the tool-call boundary after applying the existing tier rubric; inheritance is not a choice.
-- Define the shared generic-dispatch template once, then map it to Claude Code's concrete `model` argument and Codex's concrete `model` plus `reasoning_effort` arguments in their owning adapter references.
-- Bring the sync author and sync reviewer examples into compliance by pointing to or using that owned dispatch shape.
-- Preserve the existing model-tier heuristics and named-role dispatch behavior; do not create a second rubric or hard-code a list of currently available models.
+- Define the shared generic-dispatch template once with Claude Code's concrete `model` argument, then map it to Codex's concrete `model` plus `reasoning_effort` arguments in `codex-instructions.md`.
+- Bring every generic `Agent` call site across planning, implementation, integration, and interactive-mode references into compliance by pointing to or using that owned dispatch shape.
+- Preserve the existing model-tier heuristics and v0.4 role-skill dispatch behavior; do not create a second rubric or hard-code a list of currently available models.
 - Apply the repository's line-by-line DRY and Necessity gate to every changed instruction line.
 
 ## Planner Guidance
 
-The current rubric already selects Sonnet for Claude Code and medium thinking for Codex by default, but the dispatch templates and generic sync examples omit tool arguments. Keep the behavioral rule near that rubric. Harness-specific parameter names belong in `skills/using-superra/references/{claude,codex}-instructions.md`.
+The current rubric already selects Sonnet for Claude Code and medium thinking for Codex by default, but v0.4's generic dispatch templates omit explicit tool arguments. Keep the behavioral rule near that rubric. Claude uses the shared `Agent` surface; Codex-specific parameter translation belongs in `skills/using-superra/references/codex-instructions.md`.
 
 ## Results
 

--- a/superRA/agent-model-selection/01-dispatch-contract/task.md
+++ b/superRA/agent-model-selection/01-dispatch-contract/task.md
@@ -1,0 +1,23 @@
+---
+title: Define the Explicit Generic-Dispatch Contract
+status: not-started
+depends_on: []
+---
+
+## Objective
+
+Make explicit generic-agent model selection a single, actionable orchestration contract that both harness adapters and every generic dispatch call site implement without duplicating the tier rubric.
+
+- Update `agent-orchestration` so every generic dispatch explicitly chooses its model configuration at the tool-call boundary after applying the existing tier rubric; inheritance is not a choice.
+- Define the shared generic-dispatch template once, then map it to Claude Code's concrete `model` argument and Codex's concrete `model` plus `reasoning_effort` arguments in their owning adapter references.
+- Bring the sync author and sync reviewer examples into compliance by pointing to or using that owned dispatch shape.
+- Preserve the existing model-tier heuristics and named-role dispatch behavior; do not create a second rubric or hard-code a list of currently available models.
+- Apply the repository's line-by-line DRY and Necessity gate to every changed instruction line.
+
+## Planner Guidance
+
+The current rubric already selects Sonnet for Claude Code and medium thinking for Codex by default, but the dispatch templates and generic sync examples omit tool arguments. Keep the behavioral rule near that rubric. Harness-specific parameter names belong in `skills/using-superra/references/{claude,codex}-instructions.md`.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/02-enforcement-hook/task.md
+++ b/superRA/agent-model-selection/02-enforcement-hook/task.md
@@ -1,0 +1,27 @@
+---
+title: Implement the Shared Pre-Dispatch Model Gate
+status: not-started
+depends_on:
+  - 01-dispatch-contract
+---
+
+## Objective
+
+Implement one cross-platform command hook that rejects validly parsed generic-agent tool calls lacking the explicit model configuration required by the dispatch contract.
+
+- Read `PreToolUse` JSON from stdin and inspect the raw `tool_input`, not the top-level effective `model` field.
+- Recognize Claude Code `general-purpose` and Codex `default` generic types, including the harness's valid omitted-type generic form; pass named/custom/specialized agents unchanged.
+- For Claude Code, reject a missing, empty, or `inherit` model. For Codex, reject a missing or empty model or reasoning effort.
+- Return the supported `PreToolUse` deny payload with a concise reason that tells the caller which explicit argument to choose before retrying. Return parseable empty success output for compliant or unrelated calls.
+- Fail open on malformed/unreadable hook input so hook corruption cannot wedge all agent dispatches.
+- Add deterministic synthetic tests for both harness payload shapes, every missing-field branch, inheritance rejection, compliant calls, unrelated agent types/tools, malformed input, and JSON validity.
+
+## Planner Guidance
+
+Follow the existing extensionless Bash hook plus `run-hook.cmd` packaging pattern. A model allowlist would become stale and is unnecessary because each harness validates its own model and reasoning values. Keep `SubagentStart` out of the blocking path.
+
+Before locking field names, capture representative raw `PreToolUse(Agent)` payloads from the installed harness versions or their supported SDK test surfaces. If the current Codex payload cannot distinguish explicit `reasoning_effort` despite the exposed tool schema, stop and replan rather than inferring it from effective defaults.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/03-claude-wiring/task.md
+++ b/superRA/agent-model-selection/03-claude-wiring/task.md
@@ -1,0 +1,24 @@
+---
+title: Wire and Verify Claude Code Enforcement
+status: not-started
+depends_on:
+  - 02-enforcement-hook
+---
+
+## Objective
+
+Enable the shared model-selection gate on Claude Code's `PreToolUse(Agent)` path and verify that it blocks an inherited generic model before any subagent starts while allowing an explicit concrete selection.
+
+- Register the shared hook under an `Agent` matcher in the Claude hook manifest without changing unrelated lifecycle hooks.
+- Extend Claude-only manifest and hook tests to protect the matcher, command, and Claude-specific contract.
+- Run a realistic Claude CLI or Agent SDK session that captures the pre-dispatch payload and proves a missing or `inherit` model is denied and retried, while a concrete model reaches `SubagentStart`.
+- Record any documented headless-CLI limitation precisely; synthetic tests may supplement but not replace one realistic harness verification of the changed path.
+- Update only Claude-specific hook documentation where the supported behavior or troubleshooting surface changes. Leave shared cross-harness contract tests and documentation to `05-cross-harness-convergence`.
+
+## Planner Guidance
+
+Claude's documented `SubagentStart` payload omits the original Agent arguments and cannot block creation. The existing live harness notes warn that filesystem `PreToolUse` behavior differs under some `claude -p` paths; prefer the Agent SDK surface when necessary and state what the live run actually proves.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/04-codex-wiring/task.md
+++ b/superRA/agent-model-selection/04-codex-wiring/task.md
@@ -1,0 +1,24 @@
+---
+title: Wire and Verify Codex Enforcement
+status: not-started
+depends_on:
+  - 02-enforcement-hook
+---
+
+## Objective
+
+Enable the shared model-selection gate on Codex's `PreToolUse(Agent)` alias for `spawn_agent` and verify that a default generic dispatch cannot inherit either its model or reasoning effort.
+
+- Register the shared hook under an `Agent` matcher in the Codex plugin hook manifest without changing unrelated lifecycle hooks.
+- Extend Codex-only hook and plugin-manifest tests to protect the matcher, raw-argument checks, and parseable output shapes.
+- Run a realistic Codex session that captures the pre-dispatch payload and proves missing model configuration is denied before `SubagentStart`, while explicit `model` and `reasoning_effort` reach the generic subagent.
+- Distinguish the raw spawn arguments from the hook payload's top-level active-model field and from `agents.default_subagent_model` / `agents.default_subagent_reasoning_effort`; none of those defaults satisfy the explicit-choice rule.
+- Record the documented specialized-tool opt-out boundary honestly and update only Codex-specific setup/hook documentation where behavior or troubleshooting changes. Leave shared cross-harness contract tests and documentation to `05-cross-harness-convergence`.
+
+## Planner Guidance
+
+Current official Codex documentation states that `spawn_agent` matches the `Agent` hook alias and that `PreToolUse` can block or rewrite local-function calls. The installed tool schema exposes `model` and `reasoning_effort`; capture the live stdin shape before fixing parser keys. `SubagentStart` remains useful as the positive proof that the compliant call started, not as enforcement.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/05-cross-harness-convergence/task.md
+++ b/superRA/agent-model-selection/05-cross-harness-convergence/task.md
@@ -1,0 +1,25 @@
+---
+title: Converge the Cross-Harness Contract and Verification
+status: not-started
+depends_on:
+  - 03-claude-wiring
+  - 04-codex-wiring
+---
+
+## Objective
+
+Reconcile the completed Claude Code and Codex wiring into one coherent, documented hook contract and prove the combined plugin state preserves both harnesses' enforcement behavior.
+
+- Own shared cross-harness surfaces, including `tests/harness-instruction-following/test_contract.py`, `tests/check-harness-compatibility.sh`, the hook load contract/inventory, and shared hook documentation; the two upstream wiring tasks must not edit these files.
+- Verify both manifests register the same shared hook at `PreToolUse(Agent)` while retaining their unrelated harness-specific lifecycle hooks and output requirements.
+- Verify the shared policy remains single-sourced in `agent-orchestration`, with adapters expressing only harness syntax and active docs pointing to the owner rather than restating the rubric.
+- Run the complete synthetic hook suites, harness compatibility checks, instruction-following contract tests, and the two recorded live-smoke paths. Report any live test that remains opt-in with its exact command and evidence instead of presenting it as CI coverage.
+- Ensure the final diff contains no model-name allowlist, generated-agent edits, or unrelated hook behavior changes.
+
+## Planner Guidance
+
+This task is the sole owner of files that compare or describe both harnesses. Read the upstream tasks' `## Results` and their captured payload evidence before changing shared assertions so the combined tests reflect demonstrated behavior rather than assumed schema symmetry.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/05-cross-harness-convergence/task.md
+++ b/superRA/agent-model-selection/05-cross-harness-convergence/task.md
@@ -12,9 +12,9 @@ Reconcile the completed Claude Code and Codex wiring into one coherent, document
 
 - Own shared cross-harness surfaces, including `tests/harness-instruction-following/test_contract.py`, `tests/check-harness-compatibility.sh`, the hook load contract/inventory, and shared hook documentation; the two upstream wiring tasks must not edit these files.
 - Verify both manifests register the same shared hook at `PreToolUse(Agent)` while retaining their unrelated harness-specific lifecycle hooks and output requirements.
-- Verify the shared policy remains single-sourced in `agent-orchestration`, with adapters expressing only harness syntax and active docs pointing to the owner rather than restating the rubric.
+- Verify the shared policy remains single-sourced in `agent-orchestration`, with the shared dispatch surface and Codex adapter expressing only harness syntax and active docs pointing to the owner rather than restating the rubric.
 - Run the complete synthetic hook suites, harness compatibility checks, instruction-following contract tests, and the two recorded live-smoke paths. Report any live test that remains opt-in with its exact command and evidence instead of presenting it as CI coverage.
-- Ensure the final diff contains no model-name allowlist, generated-agent edits, or unrelated hook behavior changes.
+- Ensure the final diff contains no model-name allowlist, reintroduced named-agent/generator plumbing, or unrelated hook behavior changes.
 
 ## Planner Guidance
 

--- a/superRA/agent-model-selection/task.md
+++ b/superRA/agent-model-selection/task.md
@@ -1,0 +1,53 @@
+---
+title: Explicit Model Selection for Generic Agent Dispatches
+status: not-started
+depends_on: []
+---
+
+## Objective
+
+Require every generic agent dispatch in Claude Code and Codex to carry a conscious, explicit model configuration before the subagent starts, whether or not `agent-orchestration` was loaded or a superRA workflow is active.
+
+- Deny a noncompliant dispatch and require the caller to choose and retry; never inject an automatic default.
+- Target Claude Code's `general-purpose` agent and Codex's `default` or omitted generic agent type. Leave named, custom, and specialized agent types outside this hook.
+- Require a concrete Claude `model` value and reject missing, empty, or `inherit` selections.
+- Require both `model` and `reasoning_effort` on Codex generic dispatches because they are separate per-dispatch cost and capability controls.
+- Enforce at `PreToolUse` for the `Agent` tool alias. Do not use `SubagentStart` as the enforcement point because both harnesses start the subagent before that event can affect creation.
+- Avoid a model-name allowlist; the harness owns model availability and value validation.
+- Preserve valid unrelated tool calls and agent dispatches, and fail open only when the hook input itself is unreadable.
+
+### Conventions
+
+- Follow the repository's contributor discipline and DRY / Necessity gate in [`CLAUDE.md`](../../CLAUDE.md); this work changes workflow instructions and hooks, so implementation must load `skill-creator` before editing any `skills/*/SKILL.md`.
+- The generated Codex agent files [`.codex/agents/superra_implementer.toml`](../../.codex/agents/superra_implementer.toml) and [`.codex/agents/superra_reviewer.toml`](../../.codex/agents/superra_reviewer.toml) remain out of scope because this task does not change their canonical `agents/*` sources. If that boundary changes, edit the canonical agent source and regenerate with `python3 skills/codex-superra-setup/scripts/sync_codex_agents.py --project` rather than editing either TOML directly.
+
+## Planner Guidance
+
+Both harnesses now document the same usable interception point: `PreToolUse` can inspect raw local-function arguments, `spawn_agent` matches the `Agent` alias in Codex, and a deny decision prevents the call. `SubagentStart` is useful only for audit/context because it cannot stop creation. The raw tool input, not the hook payload's top-level effective model, is the evidence that the caller made an explicit choice.
+
+Keep the policy in [`skills/agent-orchestration/SKILL.md`](../../skills/agent-orchestration/SKILL.md), harness syntax in the existing Claude/Codex adapter references, and deterministic enforcement in one shared hook script. Current generic call sites are the sync author and reviewer dispatches in [`skills/superintegrate/references/sync.md`](../../skills/superintegrate/references/sync.md).
+
+Official capability references consulted during planning:
+
+- [Claude Code hooks: `PreToolUse` and `SubagentStart`](https://code.claude.com/docs/en/hooks)
+- [Claude Code subagent model selection](https://code.claude.com/docs/en/sub-agents#choose-a-model)
+- [Codex hooks: tool coverage and `PreToolUse`](https://learn.chatgpt.com/docs/hooks#tool-coverage)
+- [Codex subagent model and reasoning selection](https://learn.chatgpt.com/docs/agent-configuration/subagents#choosing-models-and-reasoning)
+
+This is a new top-level workstream because the concern crosses orchestration policy, integration's generic sync dispatches, shared hook code, and two harness adapters. The approved `interactive-mode` subtree owns human cadence and seat assignment, while `task-tree/codex-task-hooks` owns task-file reconciliation; neither owns per-dispatch model selection.
+
+## Critical Files
+
+- [`skills/agent-orchestration/SKILL.md`](../../skills/agent-orchestration/SKILL.md) — authoritative model-tier policy and dispatch mechanics
+- [`skills/superintegrate/references/sync.md`](../../skills/superintegrate/references/sync.md) — current generic author and reviewer dispatches
+- [`hooks/hooks.json`](../../hooks/hooks.json) — Claude Code lifecycle-hook wiring
+- [`hooks/hooks-codex.json`](../../hooks/hooks-codex.json) — Codex lifecycle-hook wiring
+- [`tests/harness-instruction-following/test_contract.py`](../../tests/harness-instruction-following/test_contract.py) — cross-harness static contract checks
+
+## Review Notes
+
+1. **[BLOCKING] The Claude and Codex wiring siblings have overlapping mutable ownership but no ordering or convergence contract.** The Claude task claims shared manifest/compatibility tests and active hook documentation ([03-claude-wiring/task.md:13-16](03-claude-wiring/task.md#L13-L16)); the Codex task separately claims instruction-following/compatibility tests and the same active hook documentation surface ([04-codex-wiring/task.md:13-16](04-codex-wiring/task.md#L13-L16)). Both become frontier-ready after `02-enforcement-hook`, while the parent explicitly identifies one cross-harness contract file as shared ([task.md:39-45](task.md#L39-L45)). That makes them unsafe for the workflow's normal parallel-frontier execution and leaves no single task accountable for the final cross-harness test/document state. Assign disjoint files plus one owner for every shared cross-harness surface, serialize one wiring task after the other and give the downstream task the combined-state check, or add a small convergence task depending on both.
+
+## Results
+
+(empty)

--- a/superRA/agent-model-selection/task.md
+++ b/superRA/agent-model-selection/task.md
@@ -44,10 +44,6 @@ This is a new top-level workstream because the concern crosses orchestration pol
 - [`hooks/hooks-codex.json`](../../hooks/hooks-codex.json) — Codex lifecycle-hook wiring
 - [`tests/harness-instruction-following/test_contract.py`](../../tests/harness-instruction-following/test_contract.py) — cross-harness static contract checks
 
-## Review Notes
-
-1. **[BLOCKING] The Claude and Codex wiring siblings have overlapping mutable ownership but no ordering or convergence contract.** The Claude task claims shared manifest/compatibility tests and active hook documentation ([03-claude-wiring/task.md:13-16](03-claude-wiring/task.md#L13-L16)); the Codex task separately claims instruction-following/compatibility tests and the same active hook documentation surface ([04-codex-wiring/task.md:13-16](04-codex-wiring/task.md#L13-L16)). Both become frontier-ready after `02-enforcement-hook`, while the parent explicitly identifies one cross-harness contract file as shared ([task.md:39-45](task.md#L39-L45)). That makes them unsafe for the workflow's normal parallel-frontier execution and leaves no single task accountable for the final cross-harness test/document state. Assign disjoint files plus one owner for every shared cross-harness surface, serialize one wiring task after the other and give the downstream task the combined-state check, or add a small convergence task depending on both.
-
 ## Results
 
 (empty)

--- a/superRA/agent-model-selection/task.md
+++ b/superRA/agent-model-selection/task.md
@@ -9,7 +9,7 @@ depends_on: []
 Require every generic agent dispatch in Claude Code and Codex to carry a conscious, explicit model configuration before the subagent starts, whether or not `agent-orchestration` was loaded or a superRA workflow is active.
 
 - Deny a noncompliant dispatch and require the caller to choose and retry; never inject an automatic default.
-- Target Claude Code's `general-purpose` agent and Codex's `default` or omitted generic agent type. Leave named, custom, and specialized agent types outside this hook.
+- Target Claude Code's `general-purpose` agent and Codex's `default` or omitted generic agent type. Leave non-default specialized agent types outside this hook.
 - Require a concrete Claude `model` value and reject missing, empty, or `inherit` selections.
 - Require both `model` and `reasoning_effort` on Codex generic dispatches because they are separate per-dispatch cost and capability controls.
 - Enforce at `PreToolUse` for the `Agent` tool alias. Do not use `SubagentStart` as the enforcement point because both harnesses start the subagent before that event can affect creation.
@@ -19,13 +19,13 @@ Require every generic agent dispatch in Claude Code and Codex to carry a conscio
 ### Conventions
 
 - Follow the repository's contributor discipline and DRY / Necessity gate in [`CLAUDE.md`](../../CLAUDE.md); this work changes workflow instructions and hooks, so implementation must load `skill-creator` before editing any `skills/*/SKILL.md`.
-- The generated Codex agent files [`.codex/agents/superra_implementer.toml`](../../.codex/agents/superra_implementer.toml) and [`.codex/agents/superra_reviewer.toml`](../../.codex/agents/superra_reviewer.toml) remain out of scope because this task does not change their canonical `agents/*` sources. If that boundary changes, edit the canonical agent source and regenerate with `python3 skills/codex-superra-setup/scripts/sync_codex_agents.py --project` rather than editing either TOML directly.
+- Preserve v0.4's single dispatch mechanism established by [`v04-lean-workflow/role-skills`](../v04-lean-workflow/role-skills/task.md): general-purpose/default agents load role skills at dispatch. Do not reintroduce `agents/`, `.codex/agents/`, or named-agent generator plumbing.
 
 ## Planner Guidance
 
 Both harnesses now document the same usable interception point: `PreToolUse` can inspect raw local-function arguments, `spawn_agent` matches the `Agent` alias in Codex, and a deny decision prevents the call. `SubagentStart` is useful only for audit/context because it cannot stop creation. The raw tool input, not the hook payload's top-level effective model, is the evidence that the caller made an explicit choice.
 
-Keep the policy in [`skills/agent-orchestration/SKILL.md`](../../skills/agent-orchestration/SKILL.md), harness syntax in the existing Claude/Codex adapter references, and deterministic enforcement in one shared hook script. Current generic call sites are the sync author and reviewer dispatches in [`skills/superintegrate/references/sync.md`](../../skills/superintegrate/references/sync.md).
+Keep the policy in [`skills/agent-orchestration/SKILL.md`](../../skills/agent-orchestration/SKILL.md), Claude's argument shape in the shared `Agent` dispatch templates and call sites, Codex's translation in [`skills/using-superra/references/codex-instructions.md`](../../skills/using-superra/references/codex-instructions.md), and deterministic enforcement in one shared hook script. In v0.4, every dispatched seat uses a generic/default agent that loads its role skill, so sweep every `Agent` call site across planning, implementation, integration, and interactive-mode references.
 
 Official capability references consulted during planning:
 
@@ -34,12 +34,12 @@ Official capability references consulted during planning:
 - [Codex hooks: tool coverage and `PreToolUse`](https://learn.chatgpt.com/docs/hooks#tool-coverage)
 - [Codex subagent model and reasoning selection](https://learn.chatgpt.com/docs/agent-configuration/subagents#choosing-models-and-reasoning)
 
-This is a new top-level workstream because the concern crosses orchestration policy, integration's generic sync dispatches, shared hook code, and two harness adapters. The approved `interactive-mode` subtree owns human cadence and seat assignment, while `task-tree/codex-task-hooks` owns task-file reconciliation; neither owns per-dispatch model selection.
+This remains a new top-level workstream because the concern crosses orchestration policy, every role-skill dispatch, shared hook code, and both harnesses. The approved `v04-lean-workflow/role-skills` task owns role loading and `v04-lean-workflow/workflow-defaults` owns cadence and review defaults; neither owns per-dispatch model selection. The `task-tree/codex-task-hooks` subtree owns task-file reconciliation rather than generic-agent admission.
 
 ## Critical Files
 
 - [`skills/agent-orchestration/SKILL.md`](../../skills/agent-orchestration/SKILL.md) — authoritative model-tier policy and dispatch mechanics
-- [`skills/superintegrate/references/sync.md`](../../skills/superintegrate/references/sync.md) — current generic author and reviewer dispatches
+- [`skills/using-superra/references/codex-instructions.md`](../../skills/using-superra/references/codex-instructions.md) — Codex translation of the shared `Agent` dispatch contract
 - [`hooks/hooks.json`](../../hooks/hooks.json) — Claude Code lifecycle-hook wiring
 - [`hooks/hooks-codex.json`](../../hooks/hooks-codex.json) — Codex lifecycle-hook wiring
 - [`tests/harness-instruction-following/test_contract.py`](../../tests/harness-instruction-following/test_contract.py) — cross-harness static contract checks
@@ -47,3 +47,7 @@ This is a new top-level workstream because the concern crosses orchestration pol
 ## Results
 
 (empty)
+
+## Revision Notes
+
+- Adapted during transfer to the v0.4 worktree: every dispatched seat now uses a generic/default agent with a role skill, so the contract covers all `Agent` call sites; removed v0.3 named-agent, generator, and Claude-adapter assumptions.


### PR DESCRIPTION
## Summary

- add a reviewed task tree for blocking generic-agent dispatches that omit an explicit model choice
- enforce at PreToolUse(Agent) in both Claude Code and Codex, with Codex also requiring reasoning_effort
- adapt the design to v0.4 role-skill dispatches, covering every generic Agent call site without reintroducing named agents

## Design boundary

The hook denies and asks the orchestrator to retry; it does not inject defaults or maintain a model allowlist. Specialized non-default agents stay outside the gate. SubagentStart remains verification-only because it occurs after creation.

## Verification

- ./superRA/superra task check
- python3 skills/communicate/scripts/check_markdown.py on all six task files
- git diff --check

This PR contains planning and reviewed design only; implementation is decomposed into five dependent tasks.